### PR TITLE
fixed web listen address

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -21,7 +21,7 @@ var webCmd = &cobra.Command{
 }
 
 func init() {
-	webCmd.Flags().StringVarP(&host, "host", "", "127.0.0.1", "web服务监听地址")
+	webCmd.Flags().StringVarP(&host, "host", "", "0.0.0.0", "web服务监听地址")
 	webCmd.Flags().IntVarP(&port, "port", "p", 80, "web服务启动端口")
 	webCmd.Flags().BoolVarP(&ssl, "ssl", "", false, "web服务是否以https方式运行")
 	rootCmd.AddCommand(webCmd)

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -6,6 +6,7 @@ import (
 )
 
 var (
+	host string
 	port int
 	ssl  bool
 )
@@ -15,11 +16,12 @@ var webCmd = &cobra.Command{
 	Use:   "web",
 	Short: "以web方式启动",
 	Run: func(cmd *cobra.Command, args []string) {
-		web.Start(port, ssl)
+		web.Start(host, port, ssl)
 	},
 }
 
 func init() {
+	webCmd.Flags().StringVarP(&host, "host", "", "127.0.0.1", "web服务监听地址")
 	webCmd.Flags().IntVarP(&port, "port", "p", 80, "web服务启动端口")
 	webCmd.Flags().BoolVarP(&ssl, "ssl", "", false, "web服务是否以https方式运行")
 	rootCmd.AddCommand(webCmd)

--- a/web/web.go
+++ b/web/web.go
@@ -128,7 +128,7 @@ func staticRouter(router *gin.Engine) {
 }
 
 // Start web启动入口
-func Start(port int, isSSL bool) {
+func Start(host string, port int, isSSL bool) {
 	router := gin.Default()
 	router.Use(gzip.Gzip(gzip.DefaultCompression))
 	staticRouter(router)
@@ -141,8 +141,8 @@ func Start(port int, isSSL bool) {
 	if isSSL {
 		config := core.Load("")
 		ssl := &config.SSl
-		router.RunTLS(fmt.Sprintf(":%d", port), ssl.Cert, ssl.Key)
+		router.RunTLS(fmt.Sprintf("%s:%d", host, port), ssl.Cert, ssl.Key)
 	} else {
-		router.Run(fmt.Sprintf(":%d", port))
+		router.Run(fmt.Sprintf("%s:%d", host, port))
 	}
 }


### PR DESCRIPTION
web监听地址可修改，默认127.0.0.1，根据nginx代理转发并限制请求,防止页面直接暴露到公网