### PR TITLE
安装时默认启用IPv6和IPv4监听

### DIFF
--- a/asset/trojan-install.sh
+++ b/asset/trojan-install.sh
@@ -117,7 +117,7 @@ if ! [[ -f "$CONFIGPATH" ]] || prompt "The server config already exists in $CONF
     cat > "$CONFIGPATH" << EOF
 {
     "run_type": "server",
-    "local_addr": "0.0.0.0",
+    "local_addr": "::",
     "local_port": 443,
     "remote_addr": "127.0.0.1",
     "remote_port": 80,


### PR DESCRIPTION
默认启用IPv6和IPv4监听
default enable IPV6 and IPV4 listen while installing Trojan